### PR TITLE
Fix php unit config for coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /public/storage
 /public/media
 /storage/*.key
+/tests-coverage
 /vendor
 
 .env

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,6 +4,11 @@
          bootstrap="vendor/autoload.php"
          colors="true"
 >
+    <source>
+        <include>
+            <directory suffix=".php">./app</directory>
+        </include>
+    </source>
     <testsuites>
         <testsuite name="Unit">
             <directory suffix="Test.php">./tests/Unit</directory>
@@ -12,11 +17,11 @@
             <directory suffix="Test.php">./tests/Feature</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./app</directory>
-        </whitelist>
-    </filter>
+    <coverage>
+        <report>
+            <html outputDirectory="tests-coverage-report" lowUpperBound="50" highLowerBound="90" />
+        </report>
+    </coverage>
     <php>
         <server name="APP_ENV" value="testing"/>
         <server name="BCRYPT_ROUNDS" value="4"/>


### PR DESCRIPTION
While checking the config for the unit tests I found out that the `<filter>` tag is not allowed in phpunit.xml anymore. I updated it with the required configurations for phpunit 10 and added the directory for test-coverage-reports to the .gitignore.